### PR TITLE
Implement header byte order helpers for IOTC

### DIFF
--- a/libIOTCAPIsT.c
+++ b/libIOTCAPIsT.c
@@ -9,6 +9,7 @@
  */
 
 #include <stdint.h>
+#include "libIOTCAPIsT.h"
 
 /*
  * When GCC emits stack protector code it references the variables below.  They
@@ -53,6 +54,9 @@ int64_t IOTC_Session_Read(int64_t sid, void *buf, int64_t size,
     /* Guard value changed – trigger the failure handler. */
     __stack_chk_fail();
     /* no return */
+#if defined(__GNUC__)
+    __builtin_unreachable();
+#endif
 }
 
 int64_t IOTC_sCHL_shutdown(int64_t ssl)
@@ -109,5 +113,29 @@ uint32_t IOTC_Data_hton(uint32_t data)
 #else
     return data;
 #endif
+}
+
+/*
+ * Convert the fields of an IOTC header structure between host and
+ * network byte order.  The exact semantics of the fields are not
+ * important here; the helper simply swaps each 32-bit value.
+ */
+
+void IOTC_Header_ntoh(IOTCHeader *hdr)
+{
+    hdr->flag      = IOTC_Data_ntoh(hdr->flag);
+    hdr->sid       = IOTC_Data_ntoh(hdr->sid);
+    hdr->seq       = IOTC_Data_ntoh(hdr->seq);
+    hdr->timestamp = IOTC_Data_ntoh(hdr->timestamp);
+    hdr->payload   = IOTC_Data_ntoh(hdr->payload);
+}
+
+void IOTC_Header_hton(IOTCHeader *hdr)
+{
+    hdr->flag      = IOTC_Data_hton(hdr->flag);
+    hdr->sid       = IOTC_Data_hton(hdr->sid);
+    hdr->seq       = IOTC_Data_hton(hdr->seq);
+    hdr->timestamp = IOTC_Data_hton(hdr->timestamp);
+    hdr->payload   = IOTC_Data_hton(hdr->payload);
 }
 

--- a/libIOTCAPIsT.h
+++ b/libIOTCAPIsT.h
@@ -1,0 +1,27 @@
+#ifndef LIBIOTCAPIST_H
+#define LIBIOTCAPIST_H
+
+#include <stdint.h>
+
+/*
+ * Minimal representation of the packet header used by the
+ * IOTC library.  Only the fields required by the exported
+ * byte order conversion helpers are modelled here.
+ */
+typedef struct {
+    uint32_t flag;      /* packet flags and version */
+    uint32_t sid;       /* session identifier */
+    uint32_t seq;       /* sequence number */
+    uint32_t timestamp; /* timestamp or similar */
+    uint32_t payload;   /* payload length */
+} IOTCHeader;
+
+int64_t IOTC_Session_Read(int64_t sid, void *buf, int64_t size,
+                          int64_t timeout, int32_t flags);
+int64_t IOTC_sCHL_shutdown(int64_t ssl);
+uint32_t IOTC_Data_ntoh(uint32_t data);
+uint32_t IOTC_Data_hton(uint32_t data);
+void IOTC_Header_ntoh(IOTCHeader *hdr);
+void IOTC_Header_hton(IOTCHeader *hdr);
+
+#endif /* LIBIOTCAPIST_H */

--- a/tests/test_libIOTCAPIsT.c
+++ b/tests/test_libIOTCAPIsT.c
@@ -1,11 +1,9 @@
 #include <assert.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 
-int64_t IOTC_Session_Read(int64_t sid, void *buf, int64_t size, int64_t timeout, int32_t flags);
-int64_t IOTC_sCHL_shutdown(int64_t ssl);
-uint32_t IOTC_Data_ntoh(uint32_t data);
-uint32_t IOTC_Data_hton(uint32_t data);
+#include "libIOTCAPIsT.h"
 
 /* Globals used to simulate stack guard */
 void *__stack_chk_guard = (void*)0x1;
@@ -158,6 +156,35 @@ static void test_data_roundtrip(void)
     assert(IOTC_Data_ntoh(IOTC_Data_hton(val)) == val);
 }
 
+/* Tests for IOTC_Header_ntoh and IOTC_Header_hton */
+static void test_header_ntoh_known_values(void)
+{
+    IOTCHeader hdr = {0x01020304u, 0x05060708u, 0x090a0b0cu,
+                      0x0d0e0f10u, 0x11121314u};
+    IOTC_Header_ntoh(&hdr);
+    IOTCHeader expected = {0x01020304u, 0x05060708u, 0x090a0b0cu,
+                           0x0d0e0f10u, 0x11121314u};
+    if (*(uint8_t *)&expected.flag == 0x04)
+    {
+        expected.flag = 0x04030201u;
+        expected.sid = 0x08070605u;
+        expected.seq = 0x0c0b0a09u;
+        expected.timestamp = 0x100f0e0du;
+        expected.payload = 0x14131211u;
+    }
+    assert(memcmp(&hdr, &expected, sizeof hdr) == 0);
+}
+
+static void test_header_hton_roundtrip(void)
+{
+    IOTCHeader host = {0x11223344u, 0x55667788u, 0x99aabbccu,
+                       0xddeeff00u, 0x12345678u};
+    IOTCHeader net = host;
+    IOTC_Header_hton(&net);
+    IOTC_Header_ntoh(&net);
+    assert(memcmp(&host, &net, sizeof host) == 0);
+}
+
 int main(void)
 {
     test_read_no_guard_change();
@@ -169,6 +196,8 @@ int main(void)
     test_data_ntoh_known_value();
     test_data_hton_known_value();
     test_data_roundtrip();
+    test_header_ntoh_known_values();
+    test_header_hton_roundtrip();
     printf("All tests executed\n");
     return 0;
 }


### PR DESCRIPTION
## Summary
- expose `IOTCHeader` struct and public API in new header
- implement `IOTC_Header_ntoh`/`IOTC_Header_hton` to swap all fields
- extend unit tests to cover header byte order conversions

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68a31cc370288331b54c69faaa6a4bf0