### PR TITLE
Add version query helpers

### DIFF
--- a/libIOTCAPIsT.c
+++ b/libIOTCAPIsT.c
@@ -139,3 +139,21 @@ void IOTC_Header_hton(IOTCHeader *hdr)
     hdr->payload   = IOTC_Data_hton(hdr->payload);
 }
 
+/*
+ * Retrieve the version of the IOTC library.  The shared object exposes
+ * a function that writes a 32-bit packed version number into the caller's
+ * provided pointer.  Reverse engineering shows the value 0x010d0700 which
+ * corresponds to version 1.13.7.0.
+ */
+void IOTC_Get_Version(uint32_t *pnVersion)
+{
+    if (pnVersion)
+        *pnVersion = 0x010d0700u;
+}
+
+/* Return the version string matching IOTC_Get_Version. */
+const char *IOTC_Get_Version_String(void)
+{
+    return "1.13.7.0";
+}
+

--- a/libIOTCAPIsT.h
+++ b/libIOTCAPIsT.h
@@ -23,5 +23,7 @@ uint32_t IOTC_Data_ntoh(uint32_t data);
 uint32_t IOTC_Data_hton(uint32_t data);
 void IOTC_Header_ntoh(IOTCHeader *hdr);
 void IOTC_Header_hton(IOTCHeader *hdr);
+void IOTC_Get_Version(uint32_t *pnVersion);
+const char *IOTC_Get_Version_String(void);
 
 #endif /* LIBIOTCAPIST_H */

--- a/tests/test_libIOTCAPIsT.c
+++ b/tests/test_libIOTCAPIsT.c
@@ -185,6 +185,19 @@ static void test_header_hton_roundtrip(void)
     assert(memcmp(&host, &net, sizeof host) == 0);
 }
 
+static void test_get_version(void)
+{
+    uint32_t ver = 0;
+    IOTC_Get_Version(&ver);
+    assert(ver == 0x010d0700u);
+}
+
+static void test_get_version_string(void)
+{
+    const char *s = IOTC_Get_Version_String();
+    assert(strcmp(s, "1.13.7.0") == 0);
+}
+
 int main(void)
 {
     test_read_no_guard_change();
@@ -198,6 +211,8 @@ int main(void)
     test_data_roundtrip();
     test_header_ntoh_known_values();
     test_header_hton_roundtrip();
+    test_get_version();
+    test_get_version_string();
     printf("All tests executed\n");
     return 0;
 }


### PR DESCRIPTION
## Summary
- expose `IOTC_Get_Version` and `IOTC_Get_Version_String` from libIOTCAPIsT
- cover version helpers with unit tests

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a32b4a225c83319d851831ce26ed89