### PR TITLE
Add session channel state helpers and tests

### DIFF
--- a/libIOTCAPIsT.c
+++ b/libIOTCAPIsT.c
@@ -9,6 +9,8 @@
  */
 
 #include <stdint.h>
+#include <stddef.h>
+#include <string.h>
 #include "libIOTCAPIsT.h"
 
 /*
@@ -155,5 +157,86 @@ void IOTC_Get_Version(uint32_t *pnVersion)
 const char *IOTC_Get_Version_String(void)
 {
     return "1.13.7.0";
+}
+
+/* ------------------------------------------------------------------------- */
+/* Session channel management                                                 */
+
+/*
+ * The original library exposes helpers that toggle logical channels within a
+ * session.  The real implementation likely interacts with the networking
+ * stack but for testing purposes a very small in-memory model suffices.  Each
+ * session can enable up to 32 channels which we track using a bit mask.
+ */
+
+#define MAX_TRACKED_SESSIONS 8
+
+typedef struct {
+    int64_t sid;         /* session identifier */
+    uint32_t chan_mask;  /* bit mask of enabled channels */
+} SessionEntry;
+
+static SessionEntry session_table[MAX_TRACKED_SESSIONS];
+
+/* Locate the table entry for a session, optionally creating a new one. */
+static SessionEntry *find_session(int64_t sid, int create)
+{
+    for (size_t i = 0; i < MAX_TRACKED_SESSIONS; ++i)
+        if (session_table[i].sid == sid)
+            return &session_table[i];
+
+    if (!create)
+        return NULL;
+
+    for (size_t i = 0; i < MAX_TRACKED_SESSIONS; ++i)
+        if (session_table[i].sid == 0)
+        {
+            session_table[i].sid = sid;
+            session_table[i].chan_mask = 0;
+            return &session_table[i];
+        }
+
+    return NULL; /* no space left */
+}
+
+int64_t IOTC_Session_Channel_ON(int64_t sid, int32_t chID)
+{
+    if (chID < 0 || chID >= 32)
+        return -1;
+
+    SessionEntry *entry = find_session(sid, 1);
+    if (!entry)
+        return -1;
+
+    entry->chan_mask |= (1u << chID);
+    return 0;
+}
+
+int64_t IOTC_Session_Channel_OFF(int64_t sid, int32_t chID)
+{
+    if (chID < 0 || chID >= 32)
+        return -1;
+
+    SessionEntry *entry = find_session(sid, 0);
+    if (!entry)
+        return -1;
+
+    entry->chan_mask &= ~(1u << chID);
+    if (entry->chan_mask == 0)
+        entry->sid = 0;
+
+    return 0;
+}
+
+int64_t IOTC_Session_Channel_Check_ON_OFF(int64_t sid, int32_t chID)
+{
+    if (chID < 0 || chID >= 32)
+        return 0;
+
+    SessionEntry *entry = find_session(sid, 0);
+    if (!entry)
+        return 0;
+
+    return (entry->chan_mask & (1u << chID)) ? 1 : 0;
 }
 

--- a/libIOTCAPIsT.h
+++ b/libIOTCAPIsT.h
@@ -26,4 +26,8 @@ void IOTC_Header_hton(IOTCHeader *hdr);
 void IOTC_Get_Version(uint32_t *pnVersion);
 const char *IOTC_Get_Version_String(void);
 
+int64_t IOTC_Session_Channel_ON(int64_t sid, int32_t chID);
+int64_t IOTC_Session_Channel_OFF(int64_t sid, int32_t chID);
+int64_t IOTC_Session_Channel_Check_ON_OFF(int64_t sid, int32_t chID);
+
 #endif /* LIBIOTCAPIST_H */

--- a/tests/test_libIOTCAPIsT.c
+++ b/tests/test_libIOTCAPIsT.c
@@ -129,6 +129,32 @@ static void test_shutdown_existing_error(void)
     assert(bio[22] == 1);
 }
 
+/* Tests for session channel helpers */
+static void test_channel_toggle(void)
+{
+    int64_t sid = 42;
+    int32_t ch = 3;
+    assert(IOTC_Session_Channel_Check_ON_OFF(sid, ch) == 0);
+    assert(IOTC_Session_Channel_ON(sid, ch) == 0);
+    assert(IOTC_Session_Channel_Check_ON_OFF(sid, ch) == 1);
+    assert(IOTC_Session_Channel_OFF(sid, ch) == 0);
+    assert(IOTC_Session_Channel_Check_ON_OFF(sid, ch) == 0);
+}
+
+static void test_channel_isolated_sessions(void)
+{
+    int64_t sid1 = 1, sid2 = 2;
+    int32_t ch = 1;
+    IOTC_Session_Channel_ON(sid1, ch);
+    IOTC_Session_Channel_ON(sid2, ch);
+    assert(IOTC_Session_Channel_Check_ON_OFF(sid1, ch) == 1);
+    assert(IOTC_Session_Channel_Check_ON_OFF(sid2, ch) == 1);
+    IOTC_Session_Channel_OFF(sid1, ch);
+    assert(IOTC_Session_Channel_Check_ON_OFF(sid1, ch) == 0);
+    assert(IOTC_Session_Channel_Check_ON_OFF(sid2, ch) == 1);
+    IOTC_Session_Channel_OFF(sid2, ch);
+}
+
 /* Tests for IOTC_Data_ntoh and IOTC_Data_hton */
 static void test_data_ntoh_known_value(void)
 {
@@ -206,6 +232,8 @@ int main(void)
     test_shutdown_no_existing();
     test_shutdown_existing_success();
     test_shutdown_existing_error();
+    test_channel_toggle();
+    test_channel_isolated_sessions();
     test_data_ntoh_known_value();
     test_data_hton_known_value();
     test_data_roundtrip();


### PR DESCRIPTION
## Summary
- implement in-memory tracking for session channel ON/OFF state
- expose IOTC_Session_Channel_ON/OFF/Check_ON_OFF APIs
- expand test suite with coverage for channel helpers

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68a32eba594c8331a0caf593baa6d77e