### PR TITLE
Implement basic session management helpers

### DIFF
--- a/libIOTCAPIsT.c
+++ b/libIOTCAPIsT.c
@@ -240,3 +240,24 @@ int64_t IOTC_Session_Channel_Check_ON_OFF(int64_t sid, int32_t chID)
     return (entry->chan_mask & (1u << chID)) ? 1 : 0;
 }
 
+int64_t IOTC_Session_Close(int64_t sid)
+{
+    SessionEntry *entry = find_session(sid, 0);
+    if (!entry)
+        return -1;
+    entry->sid = 0;
+    entry->chan_mask = 0;
+    return 0;
+}
+
+int32_t IOTC_Session_Get_Free_Channel(int64_t sid)
+{
+    SessionEntry *entry = find_session(sid, 1);
+    if (!entry)
+        return -1;
+    for (int32_t i = 0; i < 32; ++i)
+        if (!(entry->chan_mask & (1u << i)))
+            return i;
+    return -1;
+}
+

--- a/libIOTCAPIsT.h
+++ b/libIOTCAPIsT.h
@@ -29,5 +29,7 @@ const char *IOTC_Get_Version_String(void);
 int64_t IOTC_Session_Channel_ON(int64_t sid, int32_t chID);
 int64_t IOTC_Session_Channel_OFF(int64_t sid, int32_t chID);
 int64_t IOTC_Session_Channel_Check_ON_OFF(int64_t sid, int32_t chID);
+int64_t IOTC_Session_Close(int64_t sid);
+int32_t IOTC_Session_Get_Free_Channel(int64_t sid);
 
 #endif /* LIBIOTCAPIST_H */

--- a/tests/test_libIOTCAPIsT.c
+++ b/tests/test_libIOTCAPIsT.c
@@ -155,6 +155,29 @@ static void test_channel_isolated_sessions(void)
     IOTC_Session_Channel_OFF(sid2, ch);
 }
 
+static void test_session_close(void)
+{
+    int64_t sid = 77;
+    int32_t ch = 2;
+    IOTC_Session_Channel_ON(sid, ch);
+    assert(IOTC_Session_Channel_Check_ON_OFF(sid, ch) == 1);
+    assert(IOTC_Session_Close(sid) == 0);
+    assert(IOTC_Session_Channel_Check_ON_OFF(sid, ch) == 0);
+    assert(IOTC_Session_Close(sid) == -1);
+}
+
+static void test_session_get_free_channel(void)
+{
+    int64_t sid = 123;
+    assert(IOTC_Session_Get_Free_Channel(sid) == 0);
+    IOTC_Session_Channel_ON(sid, 0);
+    assert(IOTC_Session_Get_Free_Channel(sid) == 1);
+    for (int i = 1; i < 32; ++i)
+        IOTC_Session_Channel_ON(sid, i);
+    assert(IOTC_Session_Get_Free_Channel(sid) == -1);
+    IOTC_Session_Close(sid);
+}
+
 /* Tests for IOTC_Data_ntoh and IOTC_Data_hton */
 static void test_data_ntoh_known_value(void)
 {
@@ -234,6 +257,8 @@ int main(void)
     test_shutdown_existing_error();
     test_channel_toggle();
     test_channel_isolated_sessions();
+    test_session_close();
+    test_session_get_free_channel();
     test_data_ntoh_known_value();
     test_data_hton_known_value();
     test_data_roundtrip();


### PR DESCRIPTION
## Summary
- add `IOTC_Session_Close` to clear session table entries
- add `IOTC_Session_Get_Free_Channel` to locate the first unused channel
- extend test suite with coverage for new helpers

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a3312a8b188331848b14c34ef1c78c