### PR TITLE
Implement session ID management and configurable session table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.gradle/
+build/
+tests/test_libIOTCAPIsT

--- a/libIOTCAPIsT.c
+++ b/libIOTCAPIsT.c
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <stdlib.h>
 #include <string.h>
 #include "libIOTCAPIsT.h"
 
@@ -169,26 +170,40 @@ const char *IOTC_Get_Version_String(void)
  * session can enable up to 32 channels which we track using a bit mask.
  */
 
-#define MAX_TRACKED_SESSIONS 8
-
 typedef struct {
     int64_t sid;         /* session identifier */
     uint32_t chan_mask;  /* bit mask of enabled channels */
 } SessionEntry;
 
-static SessionEntry session_table[MAX_TRACKED_SESSIONS];
+/*
+ * The real library allows the maximum number of concurrent sessions to be
+ * configured via IOTC_Set_Max_Session_Number.  To emulate this behaviour the
+ * test implementation allocates the session table dynamically and resizes it
+ * on demand.
+ */
+static SessionEntry *session_table;      /* dynamically sized array */
+static unsigned int max_sessions = 8;    /* default capacity */
+
+/* Ensure the session table has been allocated before use. */
+static void ensure_session_table(void)
+{
+    if (!session_table)
+        session_table = calloc(max_sessions, sizeof(SessionEntry));
+}
 
 /* Locate the table entry for a session, optionally creating a new one. */
 static SessionEntry *find_session(int64_t sid, int create)
 {
-    for (size_t i = 0; i < MAX_TRACKED_SESSIONS; ++i)
+    ensure_session_table();
+
+    for (size_t i = 0; i < max_sessions; ++i)
         if (session_table[i].sid == sid)
             return &session_table[i];
 
     if (!create)
         return NULL;
 
-    for (size_t i = 0; i < MAX_TRACKED_SESSIONS; ++i)
+    for (size_t i = 0; i < max_sessions; ++i)
         if (session_table[i].sid == 0)
         {
             session_table[i].sid = sid;
@@ -197,6 +212,58 @@ static SessionEntry *find_session(int64_t sid, int create)
         }
 
     return NULL; /* no space left */
+}
+
+/* --------------------------------------------------------------------- */
+/* Session allocation helpers                                            */
+
+/* Obtain a tutk_platform_free session identifier.  The simple model uses an
+ * incrementing counter and reserves a slot in the session table for the
+ * caller.  When the table is full -1 is returned. */
+int64_t IOTC_Get_SessionID(void)
+{
+    static int64_t next_sid = 1;
+
+    ensure_session_table();
+
+    for (unsigned int attempt = 0; attempt < max_sessions; ++attempt)
+    {
+        int64_t sid = next_sid++;
+        if (next_sid <= 0)
+            next_sid = 1;
+
+        if (!find_session(sid, 0))
+        {
+            if (find_session(sid, 1))
+                return sid;
+        }
+    }
+
+    return -1; /* table full */
+}
+
+/* Set the maximum number of sessions tracked by the in-memory model.  Existing
+ * session information is preserved up to the new limit. */
+int64_t IOTC_Set_Max_Session_Number(unsigned int n)
+{
+    if (n == 0)
+        return -1;
+
+    SessionEntry *new_table = calloc(n, sizeof(SessionEntry));
+    if (!new_table)
+        return -1;
+
+    if (session_table)
+    {
+        unsigned int copy = (n < max_sessions) ? n : max_sessions;
+        for (unsigned int i = 0; i < copy; ++i)
+            new_table[i] = session_table[i];
+        free(session_table);
+    }
+
+    session_table = new_table;
+    max_sessions = n;
+    return (int64_t)n;
 }
 
 int64_t IOTC_Session_Channel_ON(int64_t sid, int32_t chID)

--- a/libIOTCAPIsT.h
+++ b/libIOTCAPIsT.h
@@ -31,5 +31,7 @@ int64_t IOTC_Session_Channel_OFF(int64_t sid, int32_t chID);
 int64_t IOTC_Session_Channel_Check_ON_OFF(int64_t sid, int32_t chID);
 int64_t IOTC_Session_Close(int64_t sid);
 int32_t IOTC_Session_Get_Free_Channel(int64_t sid);
+int64_t IOTC_Get_SessionID(void);
+int64_t IOTC_Set_Max_Session_Number(unsigned int n);
 
 #endif /* LIBIOTCAPIST_H */

--- a/libIOTCAPIsT.md
+++ b/libIOTCAPIsT.md
@@ -1,20 +1,24 @@
 # libIOTCAPIsT Library Overview
 
-## Source Stub (`libIOTCAPIsT.c`)
-`libIOTCAPIsT.c` is a generated placeholder that lists the library's entry points. Each function simply tail-calls itself, indicating that the real implementations live elsewhere (the shared object). For example:
+## Source (`libIOTCAPIsT.c`)
+`libIOTCAPIsT.c` provides a growing clean-room re-implementation of a subset of
+the original shared library.  Only functionality required for unit tests is
+modelled.  Currently implemented features include:
 
-```c
-int64_t forEachNat()
-{
-    /* tailcall */
-    return forEachNat();
-}
-```
+- Stack-protected wrapper around `IOTC_Session_Read`
+- Simplified SSL shutdown handling via `IOTC_sCHL_shutdown`
+- Endianness helpers (`IOTC_Data_{ntoh,hton}` and header conversions)
+- Lightweight in-memory session management with channel toggling
+- Retrieval of library version information
+- Allocation of session identifiers and dynamic sizing of the session table
 
-This pattern is repeated for numerous networking and utility routines.
+The goal of this file is to allow testing without the proprietary runtime.
 
 ## Shared Library (`libIOTCAPIsT.so`)
-`libIOTCAPIsT.so` is the compiled implementation used by the Android app. It is a 64-bit AArch64 ELF shared object and exports a large set of functions related to TUTK's P2P IoT connection framework, including NAT traversal, UDP/TCP connection tasks, and session management. Example exported symbols include:
+`libIOTCAPIsT.so` is the compiled implementation used by the Android app. It is
+a 64-bit AArch64 ELF shared object and exports a large set of functions related
+to TUTK's P2P IoT connection framework, including NAT traversal, UDP/TCP
+connection tasks, and session management. Example exported symbols include:
 
 - `AddUDPRelayConnectTask`
 - `IOTC_Client_Connect_By_Nebula`

--- a/tests/test_libIOTCAPIsT.c
+++ b/tests/test_libIOTCAPIsT.c
@@ -178,6 +178,20 @@ static void test_session_get_free_channel(void)
     IOTC_Session_Close(sid);
 }
 
+static void test_get_session_id_and_max_number(void)
+{
+    /* shrink table to 2 entries for testing */
+    assert(IOTC_Set_Max_Session_Number(2) == 2);
+    int64_t s1 = IOTC_Get_SessionID();
+    int64_t s2 = IOTC_Get_SessionID();
+    assert(s1 > 0 && s2 > 0 && s1 != s2);
+    assert(IOTC_Get_SessionID() == -1); /* table full */
+    IOTC_Session_Close(s1);
+    assert(IOTC_Get_SessionID() > 0); /* reuse freed slot */
+    /* expand table back to default */
+    assert(IOTC_Set_Max_Session_Number(8) == 8);
+}
+
 /* Tests for IOTC_Data_ntoh and IOTC_Data_hton */
 static void test_data_ntoh_known_value(void)
 {
@@ -259,6 +273,7 @@ int main(void)
     test_channel_isolated_sessions();
     test_session_close();
     test_session_get_free_channel();
+    test_get_session_id_and_max_number();
     test_data_ntoh_known_value();
     test_data_hton_known_value();
     test_data_roundtrip();


### PR DESCRIPTION
## Summary
- Add dynamic session table with IOTC_Get_SessionID and IOTC_Set_Max_Session_Number
- Document implemented features and ignore build artifacts
- Extend unit tests for session allocation and resizing

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a37a2bce0c83319389c0a233384fc2