### PR TITLE
Automate libIOTCAPIsT improvements with CI workflow

### DIFF
--- a/.github/workflows/continuous-improvement.yml
+++ b/.github/workflows/continuous-improvement.yml
@@ -1,0 +1,34 @@
+name: Continuous Improvement
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'libIOTCAPIsT.c'
+      - 'tests/**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run tests
+        run: make test
+
+  merge:
+    needs: test
+    if: github.event_name == 'pull_request' && success()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const {owner, repo} = context.repo;
+            const pull_number = context.payload.pull_request.number;
+            await github.rest.pulls.merge({owner, repo, pull_number});


### PR DESCRIPTION
## Summary
- add continuous-improvement workflow running tests on libIOTCAPIsT and merging passing PRs automatically

## Testing
- `make clean && make test`


------
https://chatgpt.com/codex/tasks/task_e_68a37e0b74c4833199bfb306701d6ed2